### PR TITLE
Workaround for an error in PhantomJS

### DIFF
--- a/timeslider/timeslider.js
+++ b/timeslider/timeslider.js
@@ -725,7 +725,7 @@ define(function(require, exports, module) {
              * Sets the loading state of the timeslider to match its active document's revisions fetching
              * @property {Boolean} loading
              */
-            set loading(loading) { setLoading(loading); },
+            set loading(ldng) { setLoading(ldng); },
             /**
              * Gets the timeslider's active document or null, if not any
              * @property {Document} activeDocument


### PR DESCRIPTION
This works around an error in PhantomJS. I think it is caused by a local variable having the same name as a getter.
